### PR TITLE
Add extra slash commands for increased control over OBS in-game.

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -12,7 +12,7 @@ namespace OBSPlugin
         public bool Enabled = true;
         public bool UIDetection = true;
         public string SourceName = "FFXIV";
-        public string Address = "ws://127.0.0.1:4444/";
+        public string Address = "ws://127.0.0.1:4455/"; // Default port was updated by obs-websocket. 
         public string Password = "";
         // Blur settings
         public int BlurSize = 3;


### PR DESCRIPTION
As the description states, this PR adds in commands for the following:

```
stream start/stop
replay start/save/stop
record start/pause/resume/stop
scene change
audio mute/unmute
```
The replay method will echo the saved file-name in echo chat, the scene change will switch between scenes given the name of the scene to be changed to and the audio commands will mute/unmute a specific audio source.

While I couldn't exactly do what I wanted to when I set out with this, it's still useful. Takes care of: #28 and #27.

P.S. Updated default port to `4455` to be in-line with latest obs-websocket 5.X releases.