### PR TITLE
Replace invalid characters in subfolder filename

### DIFF
--- a/PluginUI.cs
+++ b/PluginUI.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Lumina.Excel.Sheets;
 using System.IO;
 using System.Threading;
+using System.Text.RegularExpressions;
 
 namespace OBSPlugin
 {
@@ -1316,6 +1317,7 @@ namespace OBSPlugin
                     folderName = terriName.ToString();
                 }
 
+                folderName = ReplaceInvalidFilenameChars(folderName, "-");
                 curDir = Path.Combine(curDir, folderName);
             }
 
@@ -1635,6 +1637,12 @@ namespace OBSPlugin
             {
                 ImGui.EndDisabled();
             }
+        }
+
+        static string ReplaceInvalidFilenameChars(string filename, string replacement)
+        {
+            var pattern = new Regex("[<>:\"/\\\\|?*]");
+            return pattern.Replace(filename, replacement);
         }
 
         internal void Dispose()


### PR DESCRIPTION
First duty I tried this plugin in was P1S, and it happens to be one of the few that has an filename-invalid character in it's name 😄


Anyway, here is the error log that this should fix:
```
2026-05-09 12:01:08.897 +02:00 [ERR] [OBSPlugin] Error on toggle recording: System.IO.IOException: The directory name is invalid. : 'D:\Records\FFXIV\Asphodelos: The First Circle (Savage)'.
   at System.IO.FileSystem.CreateDirectory(String fullPath, Byte[] securityDescriptor)
   at System.IO.Directory.CreateDirectory(String path)
   at OBSPlugin.PluginUI.SetRecordingDir() in /work/repo/PluginUI.cs:line 1324
   at OBSPlugin.PluginUI.DrawRecord() in /work/repo/PluginUI.cs:line 1423
```

Please note that I **have not** tried to actually fully run this as a developer plugin, I have only tested the `ReplaceInvalidFilenameChars` function in isolation.